### PR TITLE
Add --skip-asm param to stub INCLUDE_ASM with NOPs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,6 +119,7 @@ pub fn process_c_file(
     compiler: &Compiler,
     assembler: &Assembler,
     workspace: &Workspace,
+    skip_asm: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let ws = workspace.path();
 
@@ -203,6 +204,11 @@ pub fn process_c_file(
         .iter()
         .map(|sym| (sym.name.clone(), sym.st_shndx))
         .collect();
+
+    if skip_asm {
+        write_dependency_file(compiler, make_rule, c_content, o_file)?;
+        return write_obj(o_file, &compiled_elf.pack());
+    }
 
     for mut asm_object /*(asm_file, main_symbol, rodata_syms, mut assembled_elf)*/ in asm_objects {
         let num_rodata_symbols = asm_object.all_symbols.len();

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,10 @@ struct Args {
     #[arg(long, hide = true)]
     target_encoding: Option<String>,
 
+    /// compile INCLUDE_ASM funcs as NOP stubs, useful for progress reporting
+    #[arg(long)]
+    skip_asm: bool,
+
     /// Keep temp files on failure for debugging.
     ///
     /// Without a value: writes files to the system temp dir and leaves them
@@ -175,6 +179,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         &compiler,
         &assembler,
         &workspace,
+        args.skip_asm,
     ) {
         eprintln!("failed to process c file: {:?}", e);
         workspace.on_failure();

--- a/tests/dependency_tests.rs
+++ b/tests/dependency_tests.rs
@@ -69,6 +69,7 @@ fn run(output: &PathBuf, extra_flags: &[&str]) {
         &make_compiler(extra_flags),
         &make_assembler(),
         &workspace(),
+        false,
     )
     .expect("process_c_file");
 }

--- a/tests/metrowrap_tests.rs
+++ b/tests/metrowrap_tests.rs
@@ -64,6 +64,7 @@ fn test_process_c_file() {
         &compiler,
         &assembler,
         &workspace(),
+        false,
     );
 
     assert!(matches!(result, Ok(())), "this is not ok: {result:?}");
@@ -107,6 +108,7 @@ fn test_process_c_file_no_include_asm() {
         &compiler,
         &assembler,
         &workspace(),
+        false,
     )
     .expect("process_c_file");
 
@@ -219,6 +221,7 @@ fn test_process_c_file_conditional_include_asm_no_include() {
         &compiler,
         &assembler,
         &workspace(),
+        false,
     )
     .expect("process_c_file");
 
@@ -352,6 +355,7 @@ fn test_process_c_file_conditional_include_asm_yes_include() {
         &compiler,
         &assembler,
         &workspace(),
+        false,
     )
     .expect("process_c_file");
 
@@ -438,6 +442,79 @@ fn test_process_c_file_conditional_include_asm_yes_include() {
 
     //  [ 6] .mwcats           LOUSER+0x4a2a82 00000000 000120 000008 00      5   0  4
     //  [ 7] .rel.mwcats       REL             00000000 000130 000008 08      1   6  0
+}
+
+#[test]
+fn test_process_c_file_skip_asm() {
+    let preprocessor = Arc::new(preprocessor::Preprocessor {
+        asm_dir_prefix: Some(PathBuf::from(".")),
+    });
+
+    let c_flags: Vec<String> = vec![
+        "-Itests/data".to_string(),
+        "-c".to_string(),
+        "-lang".to_string(),
+        "c".to_string(),
+        "-sdatathreshold".to_string(),
+        "0".to_string(),
+        "-char".to_string(),
+        "unsigned".to_string(),
+        "-fl".to_string(),
+        "divbyzerocheck".to_string(),
+        "-opt".to_string(),
+        "nointrinsics".to_string(),
+    ];
+    let compiler = compiler::Compiler::new(
+        c_flags,
+        "target/.private/bin/mwccpsp.exe".into(),
+        true,
+        "target/.private/bin/wibo".into(),
+    );
+
+    let assembler = assembler::Assembler {
+        as_path: "mipsel-linux-gnu-as".into(),
+        as_march: "allegrex".into(),
+        as_mabi: "32".into(),
+        as_flags: vec!["-G0".into()],
+        macro_inc_path: Some("tests/data/macro.inc".into()),
+    };
+
+    let c_path = PathBuf::from("tests/data/assembler.c");
+    let c_content = NamedSource {
+        source: SourceType::Path(c_path.display().to_string()),
+        content: std::fs::read(&c_path).unwrap(),
+        src_dir: PathBuf::from("tests/data"),
+    };
+
+    let output =
+        PathBuf::from("target/.private/tests/metrowrap/process_c_file/assembler-skip-asm.o");
+
+    let _result = metrowrap::process_c_file(
+        &c_content,
+        &output,
+        &preprocessor,
+        &compiler,
+        &assembler,
+        &workspace(),
+        true,
+    )
+    .expect("process_c_file");
+
+    let obj_bytes = std::fs::read(&output).expect("assembler-skip-asm.o");
+    let obj = object::File::parse(&*obj_bytes).expect("no object");
+
+    let text_section = obj
+        .sections()
+        .find(|s| matches!(s.kind(), SectionKind::Text))
+        .expect("text section");
+
+    // skip_asm writes the stub's NOP-filled placeholder rather than the real assembly
+    let text_data = text_section.data().unwrap();
+    assert_eq!(16, text_data.len());
+    assert!(
+        text_data.iter().all(|&b| b == 0),
+        "text section should be all-zero NOPs, got: {text_data:?}"
+    );
 }
 
 #[test]

--- a/tests/rodata_edge_case_tests.rs
+++ b/tests/rodata_edge_case_tests.rs
@@ -99,6 +99,7 @@ fn test_relocation_offset_equals_section_size() {
         &compiler,
         &assembler,
         &ws,
+        false,
     );
 
     assert!(result.is_ok());
@@ -271,6 +272,7 @@ fn test_only_rodata() {
         &compiler,
         &assembler,
         &ws,
+        false,
     );
 
     assert!(
@@ -333,6 +335,7 @@ fn test_sequential_file_processing() {
             &compiler,
             &assembler,
             &ws,
+            false,
         );
 
         assert!(
@@ -395,6 +398,7 @@ fn test_sh_info_bounds_checking() {
         &compiler,
         &assembler,
         &ws,
+        false,
     );
 
     assert!(result.is_ok());
@@ -465,6 +469,7 @@ fn test_identical_rodata_content() {
         &compiler,
         &assembler,
         &ws,
+        false,
     );
 
     assert!(result.is_ok());

--- a/tests/rodata_splitting_implementation_tests.rs
+++ b/tests/rodata_splitting_implementation_tests.rs
@@ -76,6 +76,7 @@ fn test_local_symbols_insertion_count() {
         &compiler,
         &assembler,
         &workspace(),
+        false,
     );
 
     assert!(result.is_ok(), "Failed to process file: {:?}", result.err());
@@ -112,6 +113,7 @@ fn test_relocation_offset_correctness() {
         &compiler,
         &assembler,
         &workspace(),
+        false,
     );
 
     assert!(result.is_ok(), "Failed to process file: {:?}", result.err());
@@ -180,6 +182,7 @@ fn test_new_relocation_sections_added() {
         &compiler,
         &assembler,
         &workspace(),
+        false,
     );
 
     assert!(result.is_ok(), "Failed to process file: {:?}", result.err());
@@ -234,6 +237,7 @@ fn test_symbol_index_updates() {
         &compiler,
         &assembler,
         &workspace(),
+        false,
     );
 
     assert!(result.is_ok(), "Failed to process file: {:?}", result.err());
@@ -287,6 +291,7 @@ fn test_relocation_sh_info_correctness() {
         &compiler,
         &assembler,
         &workspace(),
+        false,
     );
 
     assert!(result.is_ok(), "Failed to process file: {:?}", result.err());
@@ -344,6 +349,7 @@ fn test_global_symbols_from_assembly_added() {
         &compiler,
         &assembler,
         &workspace(),
+        false,
     );
 
     assert!(result.is_ok(), "Failed to process file: {:?}", result.err());
@@ -396,6 +402,7 @@ fn test_single_rodata_no_splitting() {
         &compiler,
         &assembler,
         &workspace(),
+        false,
     );
 
     assert!(result.is_ok(), "Failed to process file: {:?}", result.err());
@@ -446,6 +453,7 @@ fn test_rodata_indexes_cleared_per_file() {
             &compiler,
             &assembler,
             &workspace(),
+            false,
         );
 
         assert!(
@@ -479,6 +487,7 @@ fn test_relocation_data_packing() {
         &compiler,
         &assembler,
         &workspace(),
+        false,
     );
 
     assert!(result.is_ok(), "Failed to process file: {:?}", result.err());
@@ -540,6 +549,7 @@ fn test_complete_pipeline_integration() {
         &compiler,
         &assembler,
         &workspace(),
+        false,
     );
 
     assert!(result.is_ok(), "Pipeline failed: {:?}", result.err());


### PR DESCRIPTION
## Context

Decompilation projects (such as Castlevania: SOTN) utilize [encounter/objdiff](https://github.com/encounter/objdiff) to generate progress reports by comparing byte differences between the generated build and the target build.

Currently, we use a "dummy" `INCLUDE_ASM` macro to skip non-decompiled functions. This ensures that the report accurately reflects missing code within the .text section rather than falsely reporting a match for placeholder data.

The problem is metrowrap currently ignores the C pre-processor macro `INCLUDE_ASM` defined when a progress report needs to be generated. Because it cannot skip these assembly files during the wrapping process, it produces an object file that objdiff interprets as a 100% match. This creates "false positives" in progress reporting, making it difficult to track actual decompilation percentage.

## Solution

The new CLI switch `--skip-asm` rewrites the object file and completely skips the inclusion of the compiled assembly artifacts in it. The built file will be different from the expected object. Therefore objdiff will detect this as a difference and therefore as a lower score in the progress report.

I tested this solution in sotn-decomp, and objdiff generated the expected progress report:

```shell
make clean; make build
./sotn.sh progress pspeu

# earlier, "fuzzy_match_percent" was 100, with this PR it correctly reports 36.9
jq '.units[] | select(.name == "st.chi/chi_psp/en_breakable_wall")' build/pspeu/report.json

```